### PR TITLE
Update zk_evm Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm", branch = "v1.3.3" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm", branch = "v1.3.3", tag = “v1.3.3-rc0” }
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.3.2" }
 
 # zk_evm = {path = "../zk_evm"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm", branch = "v1.3.3", tag = “v1.3.3-rc0” }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm", tag = "v1.3.3-rc0" }
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.3.2" }
 
 # zk_evm = {path = "../zk_evm"}


### PR DESCRIPTION
### What

This PR updated the `zk_evm` dependency to refer to `v1.3.3-rc0` of branch `v1.3.3`.