### PR TITLE
Update the CI to that of v1.5.0

### DIFF
--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   cargo-fmt:
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/secrets_scanner.yaml
+++ b/.github/workflows/secrets_scanner.yaml
@@ -1,0 +1,17 @@
+name: Leaked Secrets Scan
+on: [pull_request]
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@0c66d30c1f4075cee1aada2e1ab46dabb1b0071a
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified


### PR DESCRIPTION
# What ❔

Updates the CI to that of v1.5.0.

## Why ❔

The current CI is outdated and broken.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
