### PR TITLE
Fix the static memory tracer enum

### DIFF
--- a/src/runners/compiler_tests.rs
+++ b/src/runners/compiler_tests.rs
@@ -782,6 +782,9 @@ fn run_vm_multi_contracts_inner<const N: usize, E: VmEncodingMode<N>>(
                         }
                         zk_evm::abstractions::MemoryType::Code => crate::trace::MemoryType::code,
                         zk_evm::abstractions::MemoryType::Stack => crate::trace::MemoryType::stack,
+                        zk_evm::abstractions::MemoryType::StaticMemory => {
+                            crate::trace::MemoryType::static_memory
+                        }
                     };
 
                     let page = query.location.page.0;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -51,6 +51,7 @@ pub enum MemoryType {
     code,
     calldata,
     returndata,
+    static_memory,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
# What ❔

Adds the static memory memory type to the tracer.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
