### PR TITLE
Reduce the amount of subtracted gas

### DIFF
--- a/src/runners/compiler_tests.rs
+++ b/src/runners/compiler_tests.rs
@@ -484,7 +484,7 @@ pub fn create_vm<const B: bool, const N: usize, E: VmEncodingMode<N>>(
         pc: initial_pc,
         exception_handler_location: E::PcOrImm::max(),
         ergs_remaining: zk_evm::zkevm_opcode_defs::system_params::VM_INITIAL_FRAME_ERGS
-            - 0xff000000,
+            - 0x80000000,
         this_shard_id: 0,
         caller_shard_id: 0,
         code_shard_id: 0,


### PR DESCRIPTION
# What ❔

Only subtracts the amount of gas required for the EVM interpreter stipend to work.

## Why ❔

I subtracted too much and it was breaking some gas tests.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
