### PR TITLE
fix: Changes zk_evm to use open sourced version era-zk_evm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zk_evm = { git = "https://github.com/matter-labs/zk_evm", branch = "v1.4.1" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm", branch = "v1.4.1" }
 zk_evm_abstractions = { git = "https://github.com/matter-labs/era-zk_evm_abstractions", branch = "v1.4.1" }
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 


### PR DESCRIPTION
# What ❔

Changes zk_evm to use open sourced version era-zk_evm.

## Why ❔

To allow public repos to be buildable.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
