### PR TITLE
fix: the EVM deploy tracer

### DIFF
--- a/src/evm_deploy_tracer.rs
+++ b/src/evm_deploy_tracer.rs
@@ -104,9 +104,12 @@ pub(crate) fn record_deployed_evm_bytecode<const B: bool, const N: usize, E: VmE
     let hash = hash_evm_bytecode(&published_bytecode);
     let as_words = bytes_to_be_words(published_bytecode);
 
-    state
-        .decommittment_processor
-        .populate(vec![(h256_to_u256(hash), as_words.clone())]);
+    let (_, normalized) = BlobSha256Format::normalize_for_decommitment(hash.as_fixed_bytes());
+    if state.decommittment_processor.get_preimage_by_hash(normalized).is_none() {
+        state
+            .decommittment_processor
+            .populate(vec![(h256_to_u256(hash), as_words.clone())]);
+    }
 }
 
 pub fn h256_to_u256(num: H256) -> U256 {

--- a/src/evm_deploy_tracer.rs
+++ b/src/evm_deploy_tracer.rs
@@ -105,7 +105,11 @@ pub(crate) fn record_deployed_evm_bytecode<const B: bool, const N: usize, E: VmE
     let as_words = bytes_to_be_words(published_bytecode);
 
     let (_, normalized) = BlobSha256Format::normalize_for_decommitment(hash.as_fixed_bytes());
-    if state.decommittment_processor.get_preimage_by_hash(normalized).is_none() {
+    if state
+        .decommittment_processor
+        .get_preimage_by_hash(normalized)
+        .is_none()
+    {
         state
             .decommittment_processor
             .populate(vec![(h256_to_u256(hash), as_words.clone())]);


### PR DESCRIPTION
# What ❔

If the preimage is already known to the decommiter - do not populate it.

## Why ❔

The decommiter panics when an already known preimage is populated.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
