### PR TITLE
Run Rust CI monthly and add a manual trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: "Rust CI"
 on:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: "Rust CI"
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
# What ❔

* Run the Rust CI GitHub action monthly.  
* Add a workflow_dispatch trigger.

## Why ❔

Currently 12 of the 20 tests are failing for me in Debug, e.g., with InvalidArgumentCount at src/tests/simple/mod.rs:19; this suggests a dependency has changed, since the source hasn’t changed in a year.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
